### PR TITLE
Create tasks for VS Code

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,13 @@
         {
             "label": "copy YML to BepInEx",
             "type": "shell",
-            "command": "cp -r -Force ./plugins/* 'D:/SteamLibrary/steamapps/common/Valheim/BepInEx_Krumpac/plugins/Krumpac-Krumpac_Reforge_Translations'"
+            "windows":{
+                "command": [
+                    "$ValheimDir=(Get-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Steam App 892970' -Name InstallLocation).InstallLocation;",
+                    "cp -r -Force ./plugins/* \"$ValheimDir\\BepInEx\\plugins\\Krumpac-Krumpac_Reforge_Translations\""
+                ],
+            },
+            "problemMatcher": [],
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "copy YML to BepInEx",
+            "type": "shell",
+            "command": "cp -r -Force ./plugins/* 'D:/SteamLibrary/steamapps/common/Valheim/BepInEx_Krumpac/plugins/Krumpac-Krumpac_Reforge_Translations'"
+        }
+    ]
+}


### PR DESCRIPTION
Added a task for VS Code to copy the results of the completed translation work directly to the game folder.
In file _.vscode\task.json_ you need to replace the path to your location of folder _Krumpac_Reforge_Translations_
Example:
` "command": "cp -r -Force ./plugins/* 'D:/SteamLibrary/steamapps/common/Valheim/BepInEx/plugins/Krumpac-Krumpac_Reforge_Translations'"`
